### PR TITLE
Always update schema when requested. Update IndexingInterface configuration

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,8 +3,7 @@ Name: silverstripe-forager-elastic-enterprise
 Only:
   envvarset: 'ENTERPRISE_SEARCH_API_KEY'
 After:
-  - 'silverstripe-search-service-dataobject'
-  - 'search-service-default'
+  - 'search-forager-default'
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Forager\Service\IndexConfiguration:
@@ -13,10 +12,10 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Forager\Interfaces\IndexingInterface:
     class: SilverStripe\ForagerElasticEnterprise\Service\EnterpriseSearchService
     constructor:
-      client: '%$Elastic\EnterpriseSearch\Client'
+      client: '%$Elastic\EnterpriseSearch\Client.managementClient'
       configuration: '%$SilverStripe\Forager\Service\IndexConfiguration'
       builder: '%$SilverStripe\Forager\Service\DocumentBuilder'
-  Elastic\EnterpriseSearch\Client:
+  Elastic\EnterpriseSearch\Client.managementClient:
     factory: SilverStripe\ForagerElasticEnterprise\Service\ClientFactory
     constructor:
       host: '`ENTERPRISE_SEARCH_ENDPOINT`'


### PR DESCRIPTION
I don't really see the value in only sending the request if we detect changes - ultimately it's the same number of API requests, and it just adds an extra layer of debugging complexity because there is module logic that can decide to not perform a configure action even when you've explictly requested it.

## Config change

Regarding going from `%$Elastic\EnterpriseSearch\Client` to `%$Elastic\EnterpriseSearch\Client.managementClient`.

This is a breaking change if someone has overridden this configuration, however, I would be more inclined to call this a bug. The configuration for the ES Client should have a suffix, otherwise it can cross-contaminate other modules (EG: Discoverer) that are also trying to set their own configuration for the ES Client.

The Discoverer module does already use its own suffix (`Elastic\EnterpriseSearch\Client.searchClient`), but (for whatever reason) in practice I found that this configuration was still being applied when I was performing searches through Discoverer.