### PR TITLE
Pr/ishannz/7 update

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,12 +3,12 @@ Name: silverstripe-forager-elastic-enterprise
 Only:
   envvarset: 'ENTERPRISE_SEARCH_API_KEY'
 After:
-  - 'search-forager-default'
+  - 'silverstripe-forager'
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Forager\Service\IndexConfiguration:
     constructor:
-      index_variant: '`ENTERPRISE_SEARCH_ENGINE_PREFIX`'
+      indexPrefix: '`ENTERPRISE_SEARCH_ENGINE_PREFIX`'
   SilverStripe\Forager\Interfaces\IndexingInterface:
     class: SilverStripe\ForagerElasticEnterprise\Service\EnterpriseSearchService
     constructor:

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         "Silverstripe CMS"
     ],
     "require": {
-        "php": "^8.1",
-        "silverstripe/framework": "^5.1",
-        "silverstripe/silverstripe-forager": "^1.3",
+        "php": "^8.3",
+        "silverstripe/framework": "^6.0",
+        "silverstripe/silverstripe-forager": "^2.0",
         "elastic/enterprise-search": "^8.6",
         "guzzlehttp/guzzle": "^7"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3",
-        "tractorcow/silverstripe-fluent": "^7",
+        "silverstripe/recipe-testing": "^4",
+        "tractorcow/silverstripe-fluent": "^8",
         "slevomat/coding-standard": "~8.8.0"
     },
     "repositories": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -104,20 +104,39 @@
         <exclude name="SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter"/>
         <!-- Don't force single line. Sometime multiline is just easier to read -->
         <exclude name="SlevomatCodingStandard.Functions.RequireSingleLineCall.RequiredSingleLineCall"/>
+        <!-- Attributes order - not enforcing a specific order -->
+        <exclude name="SlevomatCodingStandard.Attributes.AttributesOrder"/>
+        <!-- Allow references in tests for passing values out of closures -->
+        <exclude name="SlevomatCodingStandard.PHP.DisallowReference"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">
         <properties>
             <property name="searchAnnotations" type="bool" value="true"/>
-            <property name="ignoredAnnotationNames" type="array" value="@config"/>
+            <property name="ignoredAnnotationNames" type="array">
+                <element value="@config"/>
+            </property>
         </properties>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
             <!-- Set the root namespace for our src dir and phpunit dir. Please change these as required -->
-            <property name="rootNamespaces" type="array" value="src=>SilverStripe\ForagerElasticEnterprise,tests=>SilverStripe\ForagerElasticEnterprise\Tests"/>
-            <property name="ignoredNamespaces" type="array" value="Slevomat\Services"/>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="SilverStripe\ForagerElasticEnterprise"/>
+                <element key="tests" value="SilverStripe\ForagerElasticEnterprise\Tests"/>
+            </property>
+            <property name="ignoredNamespaces" type="array">
+                <element value="Slevomat\Services"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Correct replacement for deprecated OrderedUses sniff -->
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+        <properties>
+            <property name="caseSensitive" value="true"/>
+            <property name="psr12Compatible" value="false"/>
         </properties>
     </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,8 +6,8 @@
     </testsuite>
   </testsuites>
   <php>
-    <env name="BIFROST_ENDPOINT" value="https://fakeplace.com"/>
-    <env name="BIFROST_MANAGEMENT_API_KEY" value="fakeApiKey"/>
+    <env name="ENTERPRISE_SEARCH_ENDPOINT" value="https://fakeplace.com"/>
+    <env name="ENTERPRISE_SEARCH_API_KEY" value="fakeApiKey"/>
   </php>
   <source>
     <include>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="Default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="BIFROST_ENDPOINT" value="https://fakeplace.com"/>
+    <env name="BIFROST_MANAGEMENT_API_KEY" value="fakeApiKey"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/src/Service/ClientFactory.php
+++ b/src/Service/ClientFactory.php
@@ -12,7 +12,7 @@ class ClientFactory implements Factory
     /**
      * @throws Exception
      */
-    public function create($service, array $params = []) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    public function create(string $service, array $params = []): Client
     {
         $host = $params['host'] ?? null;
         $token = $params['token'] ?? null;

--- a/src/Service/EnterpriseSearchService.php
+++ b/src/Service/EnterpriseSearchService.php
@@ -22,7 +22,6 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forager\Exception\IndexConfigurationException;
 use SilverStripe\Forager\Exception\IndexingServiceException;
-use SilverStripe\Forager\Interfaces\BatchDocumentRemovalInterface;
 use SilverStripe\Forager\Interfaces\DocumentInterface;
 use SilverStripe\Forager\Interfaces\IndexingInterface;
 use SilverStripe\Forager\Schema\Field;
@@ -30,7 +29,7 @@ use SilverStripe\Forager\Service\DocumentBuilder;
 use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\Forager\Service\Traits\ConfigurationAware;
 
-class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemovalInterface
+class EnterpriseSearchService implements IndexingInterface
 {
 
     use Configurable;
@@ -63,10 +62,10 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
 
     public function environmentizeIndex(string $indexName): string
     {
-        $variant = IndexConfiguration::singleton()->getIndexVariant();
+        $prefix = IndexConfiguration::singleton()->getIndexPrefix();
 
-        if ($variant) {
-            return sprintf('%s-%s', $variant, $indexName);
+        if ($prefix) {
+            return sprintf('%s-%s', $prefix, $indexName);
         }
 
         return $indexName;
@@ -91,9 +90,9 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
      * @throws IndexingServiceException
      * @throws NotFoundExceptionInterface
      */
-    public function addDocument(DocumentInterface $document): ?string
+    public function addDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
-        $processedIds = $this->addDocuments([$document]);
+        $processedIds = $this->addDocuments($indexSuffix, [$document]);
 
         return array_shift($processedIds);
     }
@@ -103,7 +102,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
      * @throws IndexingServiceException
      * @throws NotFoundExceptionInterface
      */
-    public function addDocuments(array $documents): array
+    public function addDocuments(string $indexSuffix, array $documents): array
     {
         $documentMap = $this->getContentMapForDocuments($documents);
         $processedIds = [];
@@ -132,9 +131,9 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
      * @param DocumentInterface $document
      * @throws Exception
      */
-    public function removeDocument(DocumentInterface $document): ?string
+    public function removeDocument(string $indexSuffix, DocumentInterface $document): ?string
     {
-        $processedIds = $this->removeDocuments([$document]);
+        $processedIds = $this->removeDocuments($indexSuffix, [$document]);
 
         return array_shift($processedIds);
     }
@@ -143,7 +142,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
      * @param DocumentInterface[] $documents
      * @throws Exception
      */
-    public function removeDocuments(array $documents): array
+    public function removeDocuments(string $indexSuffix, array $documents): array
     {
         $documentMap = [];
         $processedIds = [];
@@ -157,7 +156,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
                 ));
             }
 
-            $indexes = $this->getConfiguration()->getIndexesForDocument($document);
+            $indexes = $this->getConfiguration()->getIndexConfigurationsForDocument($document);
 
             foreach (array_keys($indexes) as $indexName) {
                 if (!isset($documentMap[$indexName])) {
@@ -269,9 +268,9 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
     /**
      * @throws IndexingServiceException
      */
-    public function getDocument(string $id): ?DocumentInterface
+    public function getDocument(string $indexSuffix, string $id): ?DocumentInterface
     {
-        $result = $this->getDocuments([$id]);
+        $result = $this->getDocuments($indexSuffix, [$id]);
 
         return $result[0] ?? null;
     }
@@ -280,38 +279,36 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
      * @return DocumentInterface[]
      * @throws IndexingServiceException
      */
-    public function getDocuments(array $ids): array
+    public function getDocuments(string $indexSuffix, array $ids): array
     {
         $docs = [];
 
-        foreach (array_keys($this->getConfiguration()->getIndexes()) as $indexName) {
-            $request = Injector::inst()->create(
-                GetDocuments::class,
-                $this->environmentizeIndex($indexName),
-                $ids
-            );
-            $response = $this->getClient()->appSearch()
-                ->getDocuments($request)
-                ->asArray();
+        $request = Injector::inst()->create(
+            GetDocuments::class,
+            $this->environmentizeIndex($indexSuffix),
+            $ids
+        );
+        $response = $this->getClient()->appSearch()
+            ->getDocuments($request)
+            ->asArray();
 
-            $this->handleError($response);
+        $this->handleError($response);
 
-            $results = $response['results'] ?? null;
+        $results = $response['results'] ?? null;
 
-            if (!$results) {
+        if (!$results) {
+            return [];
+        }
+
+        foreach ($results as $data) {
+            $document = $this->getBuilder()->fromArray($data);
+
+            if (!$document) {
                 continue;
             }
 
-            foreach ($results as $data) {
-                $document = $this->getBuilder()->fromArray($data);
-
-                if (!$document) {
-                    continue;
-                }
-
-                // Stored by identifier as the key just in case one record exists in multiple indexes
-                $docs[$document->getIdentifier()] = $document;
-            }
+            // Stored by identifier as the key just in case one record exists in multiple indexes
+            $docs[$document->getIdentifier()] = $document;
         }
 
         return array_values($docs);
@@ -385,6 +382,72 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
     }
 
     /**
+     * @return int The number of removed Documents from this call
+     */
+    public function clearIndexDocuments(string $indexSuffix, int $batchSize): int
+    {
+        $indexName = $this->environmentizeIndex($indexSuffix);
+        $client = $this->getClient();
+        $numDeleted = 0;
+
+        $request = Injector::inst()->create(
+            ListDocuments::class,
+            $indexName
+        );
+        $request->setPageSize($batchSize);
+        $request->setCurrentPage(1);
+
+        $response = $client->appSearch()
+            ->listDocuments($request)
+            ->asArray();
+
+        $this->handleError($response);
+
+        $results = $response['results'] ?? [];
+
+        // Loop forever until we no longer get any results
+        while (count($results) > 0) {
+            $idsToRemove = [];
+
+            // Create the list of indexed documents to remove
+            foreach ($response['results'] as $doc) {
+                $idsToRemove[] = $doc['id'];
+            }
+
+            $deleteDocsRequest = Injector::inst()->create(
+                DeleteDocuments::class,
+                $indexName,
+                $idsToRemove
+            );
+            // Actually delete the documents
+            $deletedDocs = $client->appSearch()
+                ->deleteDocuments($deleteDocsRequest)
+                ->asArray();
+
+            // Keep an accurate running count of the number of documents deleted.
+            foreach ($deletedDocs as $doc) {
+                $deleted = $doc['deleted'] ?? false;
+
+                // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
+                if ($deleted) {
+                    $numDeleted += 1;
+                }
+            }
+
+            // Re-fetch $documents now that we've deleted this batch
+            $response = $client->appSearch()
+                ->listDocuments($request)
+                ->asArray();
+
+            $this->handleError($response);
+
+            $results = $response['results'] ?? [];
+        }
+
+        return $numDeleted;
+    }
+
+    /**
      * Ensure all the engines exist
      *
      * @throws IndexingServiceException
@@ -394,14 +457,16 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
     {
         $schemas = [];
 
-        foreach (array_keys($this->getConfiguration()->getIndexes()) as $indexName) {
+        foreach (array_keys($this->getConfiguration()->getIndexConfigurations()) as $indexName) {
             $this->validateIndex($indexName);
 
             $envIndex = $this->environmentizeIndex($indexName);
             $this->findOrMakeIndex($envIndex);
 
             // Fetch the Schema, as it is currently configured in our application
-            $definedSchema = $this->getSchemaForFields($this->getConfiguration()->getFieldsForIndex($indexName));
+            $definedSchema = $this->getSchemaForFields(
+                $this->getConfiguration()->getIndexDataForSuffix($indexName)->getFields()
+            );
 
             $request = Injector::inst()->create(
                 PutSchema::class,
@@ -590,7 +655,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
         // definitions
 
         // Loop through each Class that has a definition for this index
-        foreach ($this->getConfiguration()->getClassesForIndex($index) as $class) {
+        foreach ($this->getConfiguration()->getIndexDataForSuffix($index)->getClasses() as $class) {
             // Loop through each field that has been defined for that Class
             foreach ($this->getConfiguration()->getFieldsForClass($class) as $field) {
                 // Check to see if a Type has been defined, or just default to what we have defined
@@ -659,7 +724,7 @@ class EnterpriseSearchService implements IndexingInterface, BatchDocumentRemoval
                 continue;
             }
 
-            $indexes = $this->getConfiguration()->getIndexesForDocument($document);
+            $indexes = $this->getConfiguration()->getIndexConfigurationsForDocument($document);
 
             if (!$indexes) {
                 Injector::inst()->get(LoggerInterface::class)->warn(

--- a/src/Service/EnterpriseSearchService.php
+++ b/src/Service/EnterpriseSearchService.php
@@ -104,27 +104,48 @@ class EnterpriseSearchService implements IndexingInterface
      */
     public function addDocuments(string $indexSuffix, array $documents): array
     {
-        $documentMap = $this->getContentMapForDocuments($documents);
-        $processedIds = [];
+        $docsToAdd = [];
 
-        foreach ($documentMap as $indexName => $docsToAdd) {
-            $request = Injector::inst()->create(
-                IndexDocuments::class,
-                $this->environmentizeIndex($indexName),
-                $docsToAdd
-            );
-            $response = $this->getClient()->appSearch()
-                ->indexDocuments($request)
-                ->asArray();
+        foreach ($documents as $document) {
+            if (!$document instanceof DocumentInterface) {
+                throw new InvalidArgumentException(sprintf(
+                    '%s not passed an instance of %s',
+                    __FUNCTION__,
+                    DocumentInterface::class
+                ));
+            }
 
-            $this->handleError($response);
+            if (!$document->shouldIndex()) {
+                continue;
+            }
 
-            // Grab all the ID values, and also cast them to string
-            $processedIds += array_map('strval', array_column($response, 'id'));
+            try {
+                $docsToAdd[] = $this->getBuilder()->toArray($document);
+            } catch (IndexConfigurationException $e) {
+                Injector::inst()->get(LoggerInterface::class)->warning(
+                    sprintf('Failed to convert document to array: %s', $e->getMessage())
+                );
+
+                continue;
+            }
         }
 
-        // One document could have existed in multiple indexes, we only care to track it once
-        return array_unique($processedIds);
+        if (!$docsToAdd) {
+            return [];
+        }
+
+        $request = Injector::inst()->create(
+            IndexDocuments::class,
+            $this->environmentizeIndex($indexSuffix),
+            $docsToAdd
+        );
+        $response = $this->getClient()->appSearch()
+            ->indexDocuments($request)
+            ->asArray();
+
+        $this->handleError($response);
+
+        return array_unique(array_map('strval', array_column($response, 'id')));
     }
 
     /**
@@ -144,8 +165,7 @@ class EnterpriseSearchService implements IndexingInterface
      */
     public function removeDocuments(string $indexSuffix, array $documents): array
     {
-        $documentMap = [];
-        $processedIds = [];
+        $idsToRemove = [];
 
         foreach ($documents as $document) {
             if (!$document instanceof DocumentInterface) {
@@ -156,108 +176,25 @@ class EnterpriseSearchService implements IndexingInterface
                 ));
             }
 
-            $indexes = $this->getConfiguration()->getIndexConfigurationsForDocument($document);
-
-            foreach (array_keys($indexes) as $indexName) {
-                if (!isset($documentMap[$indexName])) {
-                    $documentMap[$indexName] = [];
-                }
-
-                $documentMap[$indexName][] = $document->getIdentifier();
-            }
+            $idsToRemove[] = $document->getIdentifier();
         }
 
-        foreach ($documentMap as $indexName => $idsToRemove) {
-            $request = Injector::inst()->create(
-                DeleteDocuments::class,
-                $this->environmentizeIndex($indexName),
-                $idsToRemove
-            );
-            $response = $this->getClient()->appSearch()
-                ->deleteDocuments($request)
-                ->asArray();
-
-            $this->handleError($response);
-
-            // Results here can be marked as deleted true or false. false would indicate that no document with that ID
-            // exists in Elastic - which, is the same result, really
-            // Grab all the ID values, and also cast them to string
-            $processedIds += array_map('strval', array_column($response, 'id'));
+        if (!$idsToRemove) {
+            return [];
         }
-
-        // One document could have existed in multiple indexes, we only care to track it once
-        return array_unique($processedIds);
-    }
-
-    /**
-     * Forcefully remove all documents from the provided index name. Batches the requests to Elastic based upon the
-     * configured batch size, beginning at page 1 and continuing until the index is empty.
-     *
-     * @param string $indexName The index name to remove all documents from
-     * @return int The total number of documents removed
-     */
-    public function removeAllDocuments(string $indexName): int
-    {
-        $indexName = $this->environmentizeIndex($indexName);
-        $cfg = $this->getConfiguration();
-        $client = $this->getClient();
-        $numDeleted = 0;
 
         $request = Injector::inst()->create(
-            ListDocuments::class,
-            $indexName
+            DeleteDocuments::class,
+            $this->environmentizeIndex($indexSuffix),
+            $idsToRemove
         );
-        $request->setPageSize($cfg->getBatchSize());
-        $request->setCurrentPage(1);
-
-        $response = $client->appSearch()
-            ->listDocuments($request)
+        $response = $this->getClient()->appSearch()
+            ->deleteDocuments($request)
             ->asArray();
 
         $this->handleError($response);
 
-        $results = $response['results'] ?? [];
-
-        // Loop forever until we no longer get any results
-        while (count($results) > 0) {
-            $idsToRemove = [];
-
-            // Create the list of indexed documents to remove
-            foreach ($response['results'] as $doc) {
-                $idsToRemove[] = $doc['id'];
-            }
-
-            $deleteDocsRequest = Injector::inst()->create(
-                DeleteDocuments::class,
-                $indexName,
-                $idsToRemove
-            );
-            // Actually delete the documents
-            $deletedDocs = $client->appSearch()
-                ->deleteDocuments($deleteDocsRequest)
-                ->asArray();
-
-            // Keep an accurate running count of the number of documents deleted.
-            foreach ($deletedDocs as $doc) {
-                $deleted = $doc['deleted'] ?? false;
-
-                // phpcs:ignore SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed
-                if ($deleted) {
-                    $numDeleted += 1;
-                }
-            }
-
-            // Re-fetch $documents now that we've deleted this batch
-            $response = $client->appSearch()
-                ->listDocuments($request)
-                ->asArray();
-
-            $this->handleError($response);
-
-            $results = $response['results'] ?? [];
-        }
-
-        return $numDeleted;
+        return array_unique(array_map('strval', array_column($response, 'id')));
     }
 
     public function getMaxDocumentSize(): int
@@ -690,60 +627,6 @@ class EnterpriseSearchService implements IndexingInterface
                 $map[$field->getSearchFieldName()] = $type;
             }
         }
-    }
-
-    /**
-     * @param DocumentInterface[] $documents
-     * @throws IndexingServiceException
-     * @throws NotFoundExceptionInterface
-     */
-    private function getContentMapForDocuments(array $documents): array
-    {
-        $documentMap = [];
-
-        foreach ($documents as $document) {
-            if (!$document instanceof DocumentInterface) {
-                throw new InvalidArgumentException(sprintf(
-                    '%s not passed an instance of %s',
-                    __FUNCTION__,
-                    DocumentInterface::class
-                ));
-            }
-
-            if (!$document->shouldIndex()) {
-                continue;
-            }
-
-            try {
-                $fields = $this->getBuilder()->toArray($document);
-            } catch (IndexConfigurationException $e) {
-                Injector::inst()->get(LoggerInterface::class)->warning(
-                    sprintf('Failed to convert document to array: %s', $e->getMessage())
-                );
-
-                continue;
-            }
-
-            $indexes = $this->getConfiguration()->getIndexConfigurationsForDocument($document);
-
-            if (!$indexes) {
-                Injector::inst()->get(LoggerInterface::class)->warn(
-                    sprintf('No valid indexes found for document %s, skipping...', $document->getIdentifier())
-                );
-
-                continue;
-            }
-
-            foreach (array_keys($indexes) as $indexName) {
-                if (!isset($documentMap[$indexName])) {
-                    $documentMap[$indexName] = [];
-                }
-
-                $documentMap[$indexName][] = $fields;
-            }
-        }
-
-        return $documentMap;
     }
 
 }

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\ForagerElasticEnterprise\Tests\Fake;
 
-use SilverStripe\Forager\Interfaces\DocumentInterface;
 use SilverStripe\Forager\Service\IndexConfiguration;
 
 class IndexConfigurationFake extends IndexConfiguration
@@ -37,11 +36,6 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override['include_page_html'] ?? parent::shouldIncludePageHTML();
     }
 
-    public function getIndexes(): array
-    {
-        return $this->override['indexes'] ?? parent::getIndexes();
-    }
-
     public function shouldUseSyncJobs(): bool
     {
         return $this->override['use_sync_jobs'] ?? parent::shouldUseSyncJobs();
@@ -62,24 +56,9 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override['auto_dependency_tracking'] ?? parent::shouldTrackDependencies();
     }
 
-    public function getIndexesForClassName(string $class): array
-    {
-        return $this->override[__FUNCTION__][$class] ?? parent::getIndexesForClassName($class);
-    }
-
-    public function getIndexesForDocument(DocumentInterface $doc): array
-    {
-        return $this->override[__FUNCTION__][$doc->getIdentifier()] ?? parent::getIndexesForDocument($doc);
-    }
-
     public function isClassIndexed(string $class): bool
     {
         return $this->override[__FUNCTION__][$class] ?? parent::isClassIndexed($class);
-    }
-
-    public function getClassesForIndex(string $index): array
-    {
-        return $this->override[__FUNCTION__][$index] ?? parent::getClassesForIndex($index);
     }
 
     public function getSearchableClasses(): array
@@ -95,11 +74,6 @@ class IndexConfigurationFake extends IndexConfiguration
     public function getFieldsForClass(string $class): ?array
     {
         return $this->override[__FUNCTION__][$class] ?? parent::getFieldsForClass($class);
-    }
-
-    public function getFieldsForIndex(string $index): array
-    {
-        return $this->override[__FUNCTION__][$index] ?? parent::getFieldsForIndex($index);
     }
 
     public function getIndexPrefix(): ?string

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -107,4 +107,11 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override[__FUNCTION__] ?? parent::getIndexVariant();
     }
 
+    public function setIndexVariant(?string $variant): IndexConfigurationFake
+    {
+        $this->override['getIndexVariant'] = $variant;
+
+        return $this;
+    }
+
 }

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -102,16 +102,16 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override[__FUNCTION__][$index] ?? parent::getFieldsForIndex($index);
     }
 
-    public function getIndexVariant(): ?string
+    public function getIndexPrefix(): ?string
     {
-        return $this->override[__FUNCTION__] ?? parent::getIndexVariant();
+        return $this->override[__FUNCTION__] ?? parent::getIndexPrefix();
     }
 
-    public function setIndexVariant(?string $variant): IndexConfigurationFake
+    public function setIndexPrefix(?string $indexPrefix): static
     {
-        $this->override['getIndexVariant'] = $variant;
+        $this->override['getIndexPrefix'] = $indexPrefix;
 
-        return $this;
+        return parent::setIndexPrefix($indexPrefix);
     }
 
 }

--- a/tests/Service/EnterpriseSearchServiceTest.php
+++ b/tests/Service/EnterpriseSearchServiceTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Page;
 use ReflectionMethod;
 use SilverStripe\Core\Environment;
@@ -14,7 +15,6 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forager\DataObject\DataObjectDocument;
 use SilverStripe\Forager\Extensions\SearchServiceExtension;
-use SilverStripe\Forager\Interfaces\IndexingInterface;
 use SilverStripe\Forager\Service\DocumentBuilder;
 use SilverStripe\Forager\Service\IndexConfiguration;
 use SilverStripe\ForagerElasticEnterprise\Service\EnterpriseSearchService;
@@ -69,24 +69,19 @@ class EnterpriseSearchServiceTest extends SapphireTest
     public function testEnvironmentizeIndex(): void
     {
         // Setting this to null to check that the "no prefix version works
-        IndexConfiguration::singleton()->setIndexVariant(null);
-
-        /** @var IndexingInterface|EnterpriseSearchService $indexer */
-        $indexer = Injector::inst()->get(IndexingInterface::class);
+        IndexConfiguration::singleton()->setIndexPrefix(null);
 
         // No change to our indexName should be made
-        $this->assertEquals('content', $indexer->environmentizeIndex('content'));
+        $this->assertEquals('content', $this->searchService->environmentizeIndex('content'));
 
         // Setting this back to a value to check the appending words
-        IndexConfiguration::singleton()->setIndexVariant('dev-test');
+        IndexConfiguration::singleton()->setIndexPrefix('dev-test');
 
         // Our indexName should now be updated to include our environment name
-        $this->assertEquals('dev-test-content', $indexer->environmentizeIndex('content'));
+        $this->assertEquals('dev-test-content', $this->searchService->environmentizeIndex('content'));
     }
 
-    /**
-     * @dataProvider provideFieldsForValidation
-     */
+    #[DataProvider('provideFieldsForValidation')]
     public function testValidateField(string $fieldName, bool $shouldBeValid): void
     {
         if (!$shouldBeValid) {
@@ -140,7 +135,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
             'record_id' => 'text',
         ];
 
-        $fields = $this->searchService->getConfiguration()->getFieldsForIndex('content');
+        $fields = $this->searchService->getConfiguration()->getIndexDataForSuffix('content')->getFields();
 
         // This method is private, so we need Reflection to access it
         $reflectionMethod = new ReflectionMethod(EnterpriseSearchService::class, 'getSchemaForFields');
@@ -519,22 +514,23 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
     public function testGetContentMapForDocuments(): void
     {
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
         $documentOne = $this->objFromFixture(DataObjectFake::class, 'one');
         $documentTwo = $this->objFromFixture(DataObjectFake::class, 'two');
         $documentThree = $this->objFromFixture(DataObjectFake::class, 'three');
 
         $documents = [];
+
         // This document should be indexable
         $doc1 = DataObjectDocument::create($documentOne);
-        $doc1->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
         $documents[] = $doc1;
+
         // This document should NOT be indexable
         $doc2 = DataObjectDocument::create($documentTwo);
-        $doc2->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
         $documents[] = $doc2;
+
         // This document should be indexable
-        $doc3 = DataObjectDocument::create($documentThree);
-        $doc3->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
+        $doc3 = DataObjectDocument::create($documentThree,);
         $documents[] = $doc3;
 
         $expectedMap = [
@@ -568,14 +564,19 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $reflectionMethod = new ReflectionMethod(EnterpriseSearchService::class, 'getContentMapForDocuments');
         $reflectionMethod->setAccessible(true);
 
-        // Invoke our method which will trigger 2 API calls, and we're expecting the second API call to trigger an error
-        $this->assertEquals($expectedMap, $reflectionMethod->invoke($this->searchService, $documents));
+
+        $indexData->withIndexContext(
+            function () use ($documents, $reflectionMethod, &$expectedMap): void {
+                // This determines whether the document should be added or removed from the index
+                $this->assertEquals($expectedMap, $reflectionMethod->invoke($this->searchService, $documents));
+            }
+        );
     }
 
     public function testConfigureNewField(): void
     {
-        // Make sure our IndexConfiguration has our IndexVariant set
-        IndexConfiguration::singleton()->setIndexVariant('dev-test');
+        // Make sure our IndexConfiguration has our IndexPrefix set
+        IndexConfiguration::singleton()->setIndexPrefix('dev-test');
 
         // Valid headers that we can use for each Request
         $headers = [
@@ -1109,7 +1110,13 @@ class EnterpriseSearchServiceTest extends SapphireTest
             '321',
         ];
 
-        $resultIds = $this->searchService->addDocuments('content', $documents);
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
+
+        $indexData->withIndexContext(
+            function () use ($documents, &$resultIds): void {
+                $resultIds = $this->searchService->addDocuments('content', $documents);
+            }
+        );
 
         $this->assertEqualsCanonicalizing($expectedIds, $resultIds);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1119,8 +1126,14 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
     public function testAddDocumentsEmpty(): void
     {
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
+
         // Adding an empty array of documents, we would expect no API calls to be made
-        $resultIds = $this->searchService->addDocuments('content', []);
+        $indexData->withIndexContext(
+            function () use (&$resultIds): void {
+                $resultIds = $this->searchService->addDocuments('content', []);
+            }
+        );
 
         // We would expect the results to be empty
         $this->assertEqualsCanonicalizing([], $resultIds);
@@ -1130,8 +1143,13 @@ class EnterpriseSearchServiceTest extends SapphireTest
     {
         $documentOne = $this->objFromFixture(DataObjectFake::class, 'one');
         $documents = [DataObjectDocument::create($documentOne)];
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
 
-        $this->expectExceptionMessage('Testing failure');
+        $indexData->withIndexContext(
+            function (): void {
+                $this->expectExceptionMessage('Testing failure');
+            }
+        );
 
         // Valid headers
         $headers = [
@@ -1151,7 +1169,11 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // We expect this to throw an Exception
-        $this->searchService->addDocuments('content', $documents);
+        $indexData->withIndexContext(
+            function () use (&$documents): void {
+                $this->searchService->addDocuments('content', $documents);
+            }
+        );
 
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
         // has been made
@@ -1177,8 +1199,13 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
 
-        $resultId = $this->searchService->addDocument('content', $document);
+        $indexData->withIndexContext(
+            function () use (&$document, &$resultId): void {
+                $resultId = $this->searchService->addDocument('content', $document);
+            }
+        );
 
         $this->assertEquals('doc-123', $resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1200,9 +1227,14 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
+        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
 
         // Kinda just checking that the array_shift correctly returns null if no results were presented from Elastic
-        $resultId = $this->searchService->addDocument('content', $document);
+        $indexData->withIndexContext(
+            function () use (&$document, &$resultId): void {
+                $resultId = $this->searchService->addDocument('content', $document);
+            }
+        );
 
         $this->assertNull($resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make

--- a/tests/Service/EnterpriseSearchServiceTest.php
+++ b/tests/Service/EnterpriseSearchServiceTest.php
@@ -98,7 +98,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->searchService->validateField($fieldName);
     }
 
-    public function provideFieldsForValidation(): array
+    public static function provideFieldsForValidation(): array
     {
         return [
             [
@@ -525,11 +525,17 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
         $documents = [];
         // This document should be indexable
-        $documents[] = DataObjectDocument::create($documentOne);
+        $doc1 = DataObjectDocument::create($documentOne);
+        $doc1->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
+        $documents[] = $doc1;
         // This document should NOT be indexable
-        $documents[] = DataObjectDocument::create($documentTwo);
+        $doc2 = DataObjectDocument::create($documentTwo);
+        $doc2->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
+        $documents[] = $doc2;
         // This document should be indexable
-        $documents[] = DataObjectDocument::create($documentThree);
+        $doc3 = DataObjectDocument::create($documentThree);
+        $doc3->setDataFrom($this->searchService->getConfiguration()->getIndexDataForSuffix('content'));
+        $documents[] = $doc3;
 
         $expectedMap = [
             'content' => [
@@ -873,7 +879,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
 
-        $documents = $this->searchService->getDocuments([$idOne, $idTwo]);
+        $documents = $this->searchService->getDocuments('content', [$idOne, $idTwo]);
 
         // Check that the total matches what was in the meta response
         $this->assertCount(2, $documents);
@@ -912,7 +918,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
 
-        $documents = $this->searchService->getDocuments([123, 321]);
+        $documents = $this->searchService->getDocuments('content', [123, 321]);
 
         // Check that the total matches what was in the meta response
         $this->assertCount(0, $documents);
@@ -942,7 +948,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // We expect this to throw an exception
-        $this->searchService->getDocuments([123, 321]);
+        $this->searchService->getDocuments('content', [123, 321]);
 
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
         // has been made
@@ -997,7 +1003,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
 
-        $resultDocument = $this->searchService->getDocument($id);
+        $resultDocument = $this->searchService->getDocument('content', $id);
 
         // Check that the total matches what was in the meta response
         $this->assertNotNull($resultDocument);
@@ -1029,7 +1035,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
 
-        $document = $this->searchService->getDocument(123);
+        $document = $this->searchService->getDocument('content', 123);
 
         // Check that there were no results (so we'd expect null for our one expected document)
         $this->assertNull($document);
@@ -1059,7 +1065,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // We expect this to throw an exception
-        $this->searchService->getDocument(123);
+        $this->searchService->getDocument('content', 123);
 
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
         // has been made
@@ -1103,7 +1109,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
             '321',
         ];
 
-        $resultIds = $this->searchService->addDocuments($documents);
+        $resultIds = $this->searchService->addDocuments('content', $documents);
 
         $this->assertEqualsCanonicalizing($expectedIds, $resultIds);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1114,7 +1120,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
     public function testAddDocumentsEmpty(): void
     {
         // Adding an empty array of documents, we would expect no API calls to be made
-        $resultIds = $this->searchService->addDocuments([]);
+        $resultIds = $this->searchService->addDocuments('content', []);
 
         // We would expect the results to be empty
         $this->assertEqualsCanonicalizing([], $resultIds);
@@ -1145,7 +1151,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // We expect this to throw an Exception
-        $this->searchService->addDocuments($documents);
+        $this->searchService->addDocuments('content', $documents);
 
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
         // has been made
@@ -1172,7 +1178,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         // Append this mock response to our stack
         $this->mock->append(new Response(200, $headers, $body));
 
-        $resultId = $this->searchService->addDocument($document);
+        $resultId = $this->searchService->addDocument('content', $document);
 
         $this->assertEquals('doc-123', $resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1196,7 +1202,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // Kinda just checking that the array_shift correctly returns null if no results were presented from Elastic
-        $resultId = $this->searchService->addDocument($document);
+        $resultId = $this->searchService->addDocument('content', $document);
 
         $this->assertNull($resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1252,7 +1258,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
             '123',
         ];
 
-        $resultIds = $this->searchService->addDocuments($documents);
+        $resultIds = $this->searchService->removeDocuments('content', $documents);
 
         $this->assertEqualsCanonicalizing($expectedIds, $resultIds);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1263,7 +1269,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
     public function testRemoveDocumentsEmpty(): void
     {
         // Removing an empty array of documents, we would expect no API calls to be made
-        $resultIds = $this->searchService->removeDocuments([]);
+        $resultIds = $this->searchService->removeDocuments('content', []);
 
         // We would expect the results to be empty
         $this->assertEqualsCanonicalizing([], $resultIds);
@@ -1294,7 +1300,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // We expect this to throw an Exception
-        $this->searchService->removeDocuments($documents);
+        $this->searchService->removeDocuments('content', $documents);
 
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
         // has been made
@@ -1323,7 +1329,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
 
         $expectedId = sprintf('silverstripe_searchservice_tests_fake_dataobjectfake_%s', $documentOne->ID);
 
-        $resultId = $this->searchService->removeDocument($document);
+        $resultId = $this->searchService->removeDocument('content', $document);
 
         $this->assertEquals($expectedId, $resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make
@@ -1347,7 +1353,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $body));
 
         // Kinda just checking that the array_shift correctly returns null if no results were presented from Elastic
-        $resultId = $this->searchService->removeDocument($document);
+        $resultId = $this->searchService->removeDocument('content', $document);
 
         $this->assertNull($resultId);
         // And make sure nothing is left in our Response Stack. This would indicate that every Request we expect to make

--- a/tests/Service/EnterpriseSearchServiceTest.php
+++ b/tests/Service/EnterpriseSearchServiceTest.php
@@ -512,67 +512,6 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->assertEquals(0, $this->mock->count());
     }
 
-    public function testGetContentMapForDocuments(): void
-    {
-        $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
-        $documentOne = $this->objFromFixture(DataObjectFake::class, 'one');
-        $documentTwo = $this->objFromFixture(DataObjectFake::class, 'two');
-        $documentThree = $this->objFromFixture(DataObjectFake::class, 'three');
-
-        $documents = [];
-
-        // This document should be indexable
-        $doc1 = DataObjectDocument::create($documentOne);
-        $documents[] = $doc1;
-
-        // This document should NOT be indexable
-        $doc2 = DataObjectDocument::create($documentTwo);
-        $documents[] = $doc2;
-
-        // This document should be indexable
-        $doc3 = DataObjectDocument::create($documentThree,);
-        $documents[] = $doc3;
-
-        $expectedMap = [
-            'content' => [
-                [
-                    'id' => sprintf(
-                        'silverstripe_foragerelasticenterprise_tests_fake_dataobjectfake_%s',
-                        $documentOne->ID
-                    ),
-                    'title' => 'Dataobject one',
-                    'html_text' => 'WHAT ARE WE YELLING ABOUT? Then a break Then a new line and a tab ',
-                    'record_base_class' => DataObjectFake::class,
-                    'record_id' => $documentOne->ID,
-                    'source_class' => DataObjectFake::class,
-                ],
-                [
-                    'id' => sprintf(
-                        'silverstripe_foragerelasticenterprise_tests_fake_dataobjectfake_%s',
-                        $documentThree->ID
-                    ),
-                    'title' => 'Dataobject three',
-                    'html_text' => 'WHAT ARE WE YELLING ABOUT? Then a break Then a new line and a tab ',
-                    'record_base_class' => DataObjectFake::class,
-                    'record_id' => $documentThree->ID,
-                    'source_class' => DataObjectFake::class,
-                ],
-            ],
-        ];
-
-        // This method is private, so we need Reflection to access it
-        $reflectionMethod = new ReflectionMethod(EnterpriseSearchService::class, 'getContentMapForDocuments');
-        $reflectionMethod->setAccessible(true);
-
-
-        $indexData->withIndexContext(
-            function () use ($documents, $reflectionMethod, &$expectedMap): void {
-                // This determines whether the document should be added or removed from the index
-                $this->assertEquals($expectedMap, $reflectionMethod->invoke($this->searchService, $documents));
-            }
-        );
-    }
-
     public function testConfigureNewField(): void
     {
         // Make sure our IndexConfiguration has our IndexPrefix set
@@ -1145,11 +1084,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $documents = [DataObjectDocument::create($documentOne)];
         $indexData = $this->searchService->getConfiguration()->getIndexDataForSuffix('content');
 
-        $indexData->withIndexContext(
-            function (): void {
-                $this->expectExceptionMessage('Testing failure');
-            }
-        );
+        $this->expectExceptionMessage('Testing failure');
 
         // Valid headers
         $headers = [
@@ -1393,7 +1328,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->assertEquals(0, $this->mock->count());
     }
 
-    public function testRemoveAllDocuments(): void
+    public function testClearIndexDocuments(): void
     {
         // Valid headers
         $headers = [
@@ -1502,7 +1437,7 @@ class EnterpriseSearchServiceTest extends SapphireTest
         $this->mock->append(new Response(200, $headers, $bodyFour));
         $this->mock->append(new Response(200, $headers, $bodyFive));
 
-        $numRemoved = $this->searchService->removeAllDocuments('content');
+        $numRemoved = $this->searchService->clearIndexDocuments('content', 100);
 
         // A total of 5 documents were requested to be removed, but only 4 returned deleted = true
         $this->assertEqualsCanonicalizing(4, $numRemoved);


### PR DESCRIPTION
replaces getContentMapForDocuments in favour of getting docs per index via the indexsuffix value. this is consistent with changes to the forager module 