### PR TITLE
Document the 1.x / 2.x split and alias dev-main to 2.0.x-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,21 @@ interchangably in this module. This module does not currently provide support fo
 
 ## Installation
 
+### Which version?
+
+| Line | Branch and tags | Requires | Status |
+| --- | --- | --- | --- |
+| 1.x | branch `1`, tags `1.0.0`–`1.1.0` | Silverstripe CMS 5, Forager `^1.3`, PHP `^8.1` | Supported stable line |
+| 2.x | branch `main`, tag `2.0.0-alpha1` | Silverstripe CMS 6, Forager `^2.0`, PHP `^8.3` | Alpha release |
+
+Install the latest 1.x release for CMS5 with:
+
 `composer require silverstripe/silverstripe-forager-elastic-enterprise`
+
+The 2.x line adds CMS 6 and Forager 2 support. It is tagged as an alpha because the API may change with future updates.
+Composer will not resolve it unless you opt in explicitly:
+
+`composer require silverstripe/silverstripe-forager-elastic-enterprise:^2.0@alpha`
 
 ## Activating EnterpriseSearch
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,11 @@
             "SilverStripe\\ForagerElasticEnterprise\\Tests\\": "tests/"
         }
     },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "2.0.x-dev"
+        }
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {


### PR DESCRIPTION
Follow-up to the branch/tag reorganisation.

`main` has been fast-forwarded onto PR #7 (CMS 6 / Forager 2 support) and tagged `2.0.0-alpha1`. The previous `main` is preserved unchanged as branch `1`, which holds the CMS 5 line and the existing `1.x` tags.

This PR adds the two supporting changes:

- **`composer.json`** — `extra.branch-alias` mapping `dev-main` to `2.0.x-dev`, matching what `silverstripe-forager`'s main branch does. Without it, projects tracking `dev-main` are silently moved from CMS 5 / Forager 1 code onto CMS 6 / Forager 2.
- **`README.md`** — a *Which version?* table under Installation so it is clear which line to install, and that 2.x is an alpha you have to opt into with `^2.0@alpha`.

No commits were rewritten in the reorganisation: the move to `main` was a fast-forward, so PR #7's commits keep their original hashes (`5005df1`, `b276953`) and anything pinning them still resolves.